### PR TITLE
core protect: chat loggin bypass and etc

### DIFF
--- a/src/ru/Overwrite/protect/PasswordHandler.java
+++ b/src/ru/Overwrite/protect/PasswordHandler.java
@@ -25,7 +25,10 @@ public class PasswordHandler {
         FileConfiguration config = plugin.getConfig();
         FileConfiguration data = Config.getFile(config.getString("main-settings.data-file"));
         if (input.equals(data.getString("data." + player.getName() + ".pass"))) {
-            correctPassword(player);
+            if (resync)
+                Bukkit.getScheduler().runTask(plugin, () -> correctPassword(player));
+            else
+                correctPassword(player);
         } else {
             player.sendMessage(Main.getMessagePrefixed("msg.incorrect"));
             failedPassword(player);

--- a/src/ru/Overwrite/protect/listeners/ChatListener.java
+++ b/src/ru/Overwrite/protect/listeners/ChatListener.java
@@ -19,6 +19,7 @@ public class ChatListener implements Listener {
         String msg = e.getMessage();
         if (Main.getInstance().login.containsKey(p)) {
             e.setCancelled(true);
+            e.setMessage(null);
             if (!config.getBoolean("main-settings.use-command")) {
                 Main.getInstance().passwordHandler.checkPassword(p, msg, true);
             }


### PR DESCRIPTION
- Bypassed password logging in chat by CoreProtect plugin by changing the message in AsyncPlayerChatEvent to null. (in the future, there may be problems if somewhere this value is not checked for null. In this case, it will be possible to set the value as an empty string, but it will also be logged)

- Fixed IllegalStateException error when the plugin tried to give him an effect from an asynchronous thread when the player entered. 
![image](https://user-images.githubusercontent.com/45980309/191596417-c7a9be82-ebcb-4274-a3a4-68363af62bb7.png)
