### PR TITLE
Fix players sending empty messages when admin is logging in

### DIFF
--- a/bukkit/src/main/java/ru/overwrite/protect/bukkit/listeners/ChatListener.java
+++ b/bukkit/src/main/java/ru/overwrite/protect/bukkit/listeners/ChatListener.java
@@ -6,7 +6,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-
 import ru.overwrite.protect.bukkit.PasswordHandler;
 import ru.overwrite.protect.bukkit.ServerProtectorManager;
 import ru.overwrite.protect.bukkit.api.ServerProtectorAPI;
@@ -14,14 +13,11 @@ import ru.overwrite.protect.bukkit.utils.Config;
 import ru.overwrite.protect.bukkit.utils.Utils;
 
 public class ChatListener implements Listener {
-
-	private final ServerProtectorManager instance;
 	private final ServerProtectorAPI api;
 	private final PasswordHandler passwordHandler;
 	private final Config pluginConfig;
 
 	public ChatListener(ServerProtectorManager plugin) {
-		instance = plugin;
 		pluginConfig = plugin.getPluginConfig();
 		passwordHandler = plugin.getPasswordHandler();
 		api = plugin.getPluginAPI();
@@ -29,47 +25,45 @@ public class ChatListener implements Listener {
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onChat(AsyncPlayerChatEvent e) {
-		if (instance.login.isEmpty())
-			return;
 		Player p = e.getPlayer();
-		if (api.isCaptured(p)) {
-			String msg = e.getMessage();
-			e.setCancelled(true);
-			if (!pluginConfig.main_settings_use_command) {
-				String inputPass = pluginConfig.encryption_settings_enable_encryption ? Utils.encryptPassword(false, msg, pluginConfig.encryption_settings_encrypt_methods) : msg;
-				passwordHandler.checkPassword(p, inputPass, true);
-			}
+		if (!api.isCaptured(p)) {
+			return;
 		}
+		if (!pluginConfig.main_settings_use_command) {
+			String message = e.getMessage();
+			String inputPass = pluginConfig.encryption_settings_enable_encryption
+					? Utils.encryptPassword(false, message, pluginConfig.encryption_settings_encrypt_methods)
+					: message;
+			passwordHandler.checkPassword(p, inputPass, true);
+		}
+		e.setCancelled(true);
 		e.setMessage("");
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onCommand(PlayerCommandPreprocessEvent e) {
-		if (instance.login.isEmpty())
-			return;
 		Player p = e.getPlayer();
-		if (!api.isCaptured(p))
+		if (!api.isCaptured(p)) {
 			return;
-		e.setCancelled(true);
+		}
 		if (pluginConfig.main_settings_use_command) {
 			String message = e.getMessage();
 			String label = cutCommand(message).toLowerCase();
 			if (label.equals("/" + pluginConfig.main_settings_pas_command)) {
-				e.setCancelled(false);
 				return;
 			} else {
 				for (String command : pluginConfig.allowed_commands) {
 					if (label.equals(command) || message.equalsIgnoreCase(command)) {
-						e.setCancelled(false);
 						return;
 					}
 				}
 			}
 		}
+		e.setCancelled(true);
 		e.setMessage("");
 	}
 
-	private String cutCommand(String str) {
+	private static String cutCommand(String str) {
 		int index = str.indexOf(' ');
 		return index == -1 ? str : str.substring(0, index);
 	}


### PR DESCRIPTION
Found out an issue when I was looking through a code - `ChatListener#onChat` doesn't check who sent a message when clearing it. Tested it, and chat indeed doesn't work.

As I was there, I've also cleaned up some logic. e.g. useless `isEmpty` check and inconsistent usage of `api.isCaptured`. Also, `e.setCancelled(false)` may break third-party plugins logic, so I've just moved things around to avoid it.